### PR TITLE
【Fixed】HTML取得失敗時は既読フラグを更新しないようにする

### DIFF
--- a/lib/tasks/batch.rb
+++ b/lib/tasks/batch.rb
@@ -9,8 +9,8 @@ class Tasks::Batch
     updated = []
     Page.all.each do |page|
       new_html = page.get_html(page.url)
-      # ページに変更があった場合
-      unless page.html == new_html
+      # ページに変更あり、かつHTMLの取得に成功した場合
+      unless page.html == new_html && new_html.blank?
         page.html = new_html
         page.save
         # 未読に戻す


### PR DESCRIPTION
### 対応するissue
connects to #30
### 作業概要(issueの内容)
* 定時バッチ処理でHTMLページ取得に失敗した際には、既読フラグを更新しないようにする。
